### PR TITLE
Tumblr api key fix, plus more Javadoc stuff.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.rarchives.ripme</groupId>
   <artifactId>ripme</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.10</version>
+  <version>1.7.11</version>
   <name>ripme</name>
   <url>http://rip.rarchives.com</url>
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.rarchives.ripme</groupId>
   <artifactId>ripme</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.11</version>
+  <version>1.7.12</version>
   <name>ripme</name>
   <url>http://rip.rarchives.com</url>
   <properties>

--- a/ripme.json
+++ b/ripme.json
@@ -1,6 +1,7 @@
 {
-    "latestVersion": "1.7.11",
+    "latestVersion": "1.7.12",
     "changeList": [
+        "1.7.12: Instagram ripper no longer 403s on certain images",
         "1.7.11: Added gwarchives support to the cheveretoRipper; Gfycat Tests & Fix for bad reddit submissions; instagram ripper can now be made to skip videos",
         "1.7.10: Added basic pornpics.com ripper; Fixed hentai.cafe regex",
         "1.7.9: FuraffinityRipper can now rip non-public albums; Added 2 new api keys, ripper can now download raw images from tumblr; Erome ripper now matchs links without the www; Tumblr ripper now tells the user if it hits the rate limit",

--- a/ripme.json
+++ b/ripme.json
@@ -1,6 +1,7 @@
 {
-    "latestVersion": "1.7.10",
+    "latestVersion": "1.7.11",
     "changeList": [
+        "1.7.11: Added gwarchives support to the cheveretoRipper; Gfycat Tests & Fix for bad reddit submissions; instagram ripper can now be made to skip videos",
         "1.7.10: Added basic pornpics.com ripper; Fixed hentai.cafe regex",
         "1.7.9: FuraffinityRipper can now rip non-public albums; Added 2 new api keys, ripper can now download raw images from tumblr; Erome ripper now matchs links without the www; Tumblr ripper now tells the user if it hits the rate limit",
         "1.7.8: Forced https for tumblr image links; Fixed imgur album filenames; SankakuComplexRipper now downloads full sized images; Added dribbble.com ripper; Added comfirm button for clearing history",

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -161,6 +161,8 @@ public class InstagramRipper extends AbstractHTMLRipper {
     }
 
     private String getOriginalUrl(String imageURL) {
+        // Without this regex most images will return a 403 error
+        imageURL = imageURL.replaceAll("vp/[a-zA-Z0-9]*/", "");
         imageURL = imageURL.replaceAll("scontent.cdninstagram.com/hphotos-", "igcdn-photos-d-a.akamaihd.net/hphotos-ak-");
         // TODO replace this with a single regex
         imageURL = imageURL.replaceAll("p150x150/", "");
@@ -177,6 +179,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
         imageURL = imageURL.replaceAll("s720x720/", "");
         imageURL = imageURL.replaceAll("s1080x1080/", "");
         imageURL = imageURL.replaceAll("s2048x2048/", "");
+
         
         // Instagram returns cropped images to unauthenticated applications to maintain legacy support. 
         // To retrieve the uncropped image, remove this segment from the URL. 
@@ -232,7 +235,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
                         if (imageURLs.size() == 0) {
                             // We add this one item to the array because either wise
                             // the ripper will error out because we returned an empty array
-                            imageURLs.add(data.getString("thumbnail_src"));
+                            imageURLs.add(getOriginalUrl(data.getString("thumbnail_src")));
                         }
                         addURLToDownload(new URL(getOriginalUrl(data.getString("thumbnail_src"))), image_date);
                     } else {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -34,23 +34,30 @@ public class TumblrRipper extends AlbumRipper {
     private ALBUM_TYPE albumType;
     private String subdomain, tagName, postNumber;
 
-    private static String TUMBLR_AUTH_CONFIG_KEY = "tumblr.auth";
+    private static final String TUMBLR_AUTH_CONFIG_KEY = "tumblr.auth";
 
     private static boolean useDefaultApiKey = false; // fall-back for bad user-specified key
-    private static final List<String> apiKeys = Arrays.asList("JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX",
-            "FQrwZMCxVnzonv90rgNUJcAk4FpnoS0mYuSuGYqIpM2cFgp9L4",
-            "qpdkY6nMknksfvYAhf2xIHp0iNRLkMlcWShxqzXyFJRxIsZ1Zz");
-    private static final String API_KEY = apiKeys.get(new Random().nextInt(apiKeys.size()));
+    private static final List<String> APIKEYS = Arrays.asList("JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX",
+                                                              "FQrwZMCxVnzonv90rgNUJcAk4FpnoS0mYuSuGYqIpM2cFgp9L4",
+                                                              "qpdkY6nMknksfvYAhf2xIHp0iNRLkMlcWShxqzXyFJRxIsZ1Zz");
+    private static int genNum = new Random().nextInt(APIKEYS.size());
+    private static final String API_KEY = APIKEYS.get(genNum); // Select random API key from APIKEYS
 
-
-    private static String getApiKey() {
+    /**
+     * Gets the API key. 
+     * Chooses between default/included keys & user specified ones (from the config file).
+     * @return Tumblr API key
+     */
+    public static String getApiKey() {
         if (useDefaultApiKey || Utils.getConfigString(TUMBLR_AUTH_CONFIG_KEY, "JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX").equals("JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX")) {
             logger.info("Using api key: " + API_KEY);
             return API_KEY;
         } else {
-            logger.info("Using user tumblr.auth api key");
-            return Utils.getConfigString(TUMBLR_AUTH_CONFIG_KEY, "JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX");
+            String userDefinedAPIKey = Utils.getConfigString(TUMBLR_AUTH_CONFIG_KEY, "JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX");
+            logger.info("Using user tumblr.auth api key: " + userDefinedAPIKey);
+            return userDefinedAPIKey;
         }
+       
     }
 
     public TumblrRipper(URL url) throws IOException {
@@ -64,7 +71,13 @@ public class TumblrRipper extends AlbumRipper {
     public boolean canRip(URL url) {
         return url.getHost().endsWith(DOMAIN);
     }
-
+    
+    /**
+     * Sanitizes URL.
+     * @param url URL to be sanitized.
+     * @return Sanitized URL
+     * @throws MalformedURLException 
+     */
     @Override
     public URL sanitizeURL(URL url) throws MalformedURLException {
         String u = url.toExternalForm();

--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -21,7 +21,7 @@ import com.rarchives.ripme.utils.Utils;
 public class UpdateUtils {
 
     private static final Logger logger = Logger.getLogger(UpdateUtils.class);
-    private static final String DEFAULT_VERSION = "1.7.11";
+    private static final String DEFAULT_VERSION = "1.7.12";
     private static final String REPO_NAME = "ripmeapp/ripme";
     private static final String updateJsonURL = "https://raw.githubusercontent.com/" + REPO_NAME + "/master/ripme.json";
     private static final String mainFileName = "ripme.jar";

--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -21,7 +21,7 @@ import com.rarchives.ripme.utils.Utils;
 public class UpdateUtils {
 
     private static final Logger logger = Logger.getLogger(UpdateUtils.class);
-    private static final String DEFAULT_VERSION = "1.7.10";
+    private static final String DEFAULT_VERSION = "1.7.11";
     private static final String REPO_NAME = "ripmeapp/ripme";
     private static final String updateJsonURL = "https://raw.githubusercontent.com/" + REPO_NAME + "/master/ripme.json";
     private static final String mainFileName = "ripme.jar";


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Fixes API choosing. Creates Random objects, generates a number, then feeds
that number to API_KEY.

This is as opposed to the previous way where it created the Random object,
generated a number, then fed it all in a single line.

Also more comments.

# Testing

Tested by hand to see which API keys will be generated.
**Out of 10 tries:**
- 4 were FQrw...
- 3 were JFN...
- 3 were qpd...

So all in all, very even. 

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
